### PR TITLE
Move @types/google-apps-script to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "gcal-to-todoist-gas",
       "version": "1.0.0",
       "license": "ISC",
-      "dependencies": {
-        "@types/google-apps-script": "1.0.7"
-      },
       "devDependencies": {
+        "@types/google-apps-script": "1.0.7",
         "@typescript-eslint/eslint-plugin": "^2.12.0",
         "@typescript-eslint/parser": "^2.12.0",
         "clasp": "^1.0.0",
@@ -51,7 +49,8 @@
     "node_modules/@types/google-apps-script": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-1.0.7.tgz",
-      "integrity": "sha512-qLSO3MZDf7k8FLiSLFWFri8wnzqdgWBrDHpt7Fhh8oGJ196LVAToyFpksgx7gGbKwMFPxo8RnCm9bl2FpfM9Bw=="
+      "integrity": "sha512-qLSO3MZDf7k8FLiSLFWFri8wnzqdgWBrDHpt7Fhh8oGJ196LVAToyFpksgx7gGbKwMFPxo8RnCm9bl2FpfM9Bw==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "@types/google-apps-script": "1.0.7"
-  },
   "devDependencies": {
+    "@types/google-apps-script": "1.0.7",
     "@typescript-eslint/eslint-plugin": "^2.12.0",
     "@typescript-eslint/parser": "^2.12.0",
     "clasp": "^1.0.0",


### PR DESCRIPTION
`@types/google-apps-script` is not needed on runtime.